### PR TITLE
Prevent crash in j2objc transpiled code when compiled with optimizations (Release build)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: java
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
 
 cache:
   directories:

--- a/stream/src/main/java/com/annimon/stream/Stream.java
+++ b/stream/src/main/java/com/annimon/stream/Stream.java
@@ -12,6 +12,7 @@ import java.io.Closeable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -45,7 +46,7 @@ public class Stream<T> implements Closeable {
      */
     public static <K, V> Stream<Map.Entry<K, V>> of(Map<K, V> map) {
         Objects.requireNonNull(map);
-        return new Stream<Map.Entry<K, V>>(map.entrySet());
+        return new Stream<Map.Entry<K, V>>(new HashSet<>(map.entrySet()));
     }
 
     /**
@@ -1027,7 +1028,7 @@ public class Stream<T> implements Closeable {
      */
     public <K> Stream<Map.Entry<K, List<T>>> groupBy(final Function<? super T, ? extends K> classifier) {
         Map<K, List<T>> map = collect(Collectors.<T, K>groupingBy(classifier));
-        return new Stream<Map.Entry<K, List<T>>>(params, map.entrySet());
+        return new Stream<Map.Entry<K, List<T>>>(params, new HashSet<>(map.entrySet()));
     }
 
     /**


### PR DESCRIPTION
A particular feature of a map `entrySet` method causes problems in transpiled code:
`Returns a Set view of the mappings contained in this map. The set is backed by the map, so changes to the map are reflected in the set, and vice-versa.`

The problems is caused by the iOS implementation that keeps the backing map as a @weakOuter. Because of this, the `Set` returned by the `entrySet()` method cannot safely outlive it’s backing Hashmap.
```
 @WeakOuter
    private final class EntrySet extends AbstractSet<Map.Entry<K,V>> {
        public Iterator<Map.Entry<K,V>> iterator() {
            return newEntryIterator();
        }
    }
```

It's fairly easy to get this to crash. The following crashes on the second line of the `test()` method:
```
    private void test() {
        Set<Map.Entry<String, String>> entries = getEntriesFromMapCreatedInFunction();
        entries.iterator().hasNext();    
    }

    private Set<Map.Entry<String, String>> getEntriesFromMapCreatedInFunction() {
        Map<String, String> testMap = new HashMap<>();
        testMap.put("john", "doe");
        testMap.put("jake", "bower");
        testMap.put("winterfest", "soon");
        return testMap.entrySet();
    }
```
This is caused because the entrySet accesses it's backingMap when .iterator() is called, but the map was releases upon exit from `getEntriesFromMapCreatedInFunction()`

By copying the entrySet into a standard hashSet, we allow the set to outlive it’s backing map. ie like this:
```
return new HashSet<>(testMap.entrySet())
```

_Note: `Collections.unmodifiableSet()` does not fix the problem because it does not copy the set._

This breaks the entrySet contract, but since the **Stream API** is a functional API and it uses the entry set as a set, it should not cause any problems.