### PR TITLE
Support J2ObjC 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: java
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk11
 
 cache:
   directories:

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'java-library'
     id 'me.champeau.gradle.jmh'
     id 'mirego.publish' version '1.0'
-    id 'mirego.release' version '1.10'
-    id 'mirego.j2objc' version '1.49'
+    id 'mirego.release' version '1.13'
+    id 'mirego.j2objc' version '1.59'
 }
 
 archivesBaseName = 'stream'
@@ -11,6 +11,7 @@ group = 'com.mirego.annimon'
 
 sourceCompatibility = '1.7'
 targetCompatibility = '1.7'
+
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 if (!hasProperty('mainClass')) {
@@ -50,31 +51,23 @@ j2objc {
     version = '1.0.0.2'
 
     podName = 'lightweight-stream-api'
+
     prefixes = [
             'com.annimon.stream.*': 'CAS'
     ]
-    incremental = false
-    lintAllowWarnings = true
 
-    options += ' --header-mapping header-mapping.j2objc'
+    options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --no-package-directories --nullability --swift-friendly --header-mapping header-mapping.j2objc'
 }
 
 tasks['j2objc'].doLast {
     // Some hacking:
-    // The following files generate header file names that clash with jre-emul after transpilling:
-    // Optional.java
-    // Function.java
-    // Objects.java
-    // Predicate.java
-    // Supplier.java
-    //
-    // Renaming header and source files to CAS*.h and CAS*.m and the --header-mapping replace the #include references.
-
-    renameHeader('Optional', 'CAS')
-    renameHeader('Function', 'CAS')
-    renameHeader('Objects', 'CAS')
-    renameHeader('Predicate', 'CAS')
-    renameHeader('Supplier', 'CAS')
+    // The following files generate header file names that clash with jre-emul after transpilling
+    // Renaming header and source files to CAS*.h and CAS*.m and the --header-mapping replace the #include references
+    renameHeader('Optional', 'CAS') // Optional.java
+    renameHeader('Function', 'CAS') // Function.java
+    renameHeader('Objects', 'CAS') // Objects.java
+    renameHeader('Predicate', 'CAS') // Predicate.java
+    renameHeader('Supplier', 'CAS') // Supplier.java
 }
 
 def renameHeader(fileName, prefix) {

--- a/stream/lightweight-stream-api.podspec.template
+++ b/stream/lightweight-stream-api.podspec.template
@@ -5,16 +5,20 @@ Pod::Spec.new do |s|
   s.summary  = 'Stream api port to Java 7.'
   s.homepage = 'http://www.mirego.com'
   s.authors  = { 'Mirego, Inc.' => 'info@mirego.com' }
-  s.source   = { :http => "${sourceUrl}",
-                 :sha1 => '${sourceSha1}' }
-  s.requires_arc = true
+  s.source   = { :git => 'git@github.com:mirego/Lightweight-Stream-API.git', :tag => 'lightweight-stream-' + s.version.to_s }
+  s.requires_arc = false
 
-  s.ios.deployment_target = '7.0'
-  s.osx.deployment_target = '10.11'
+  s.prepare_command = <<-CMD
+    export ANDROID_HOME="\${ANDROID_HOME:-\$HOME/Library/Android/sdk}"
+    ./gradlew j2objc
+  CMD
+
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.6'
   s.watchos.deployment_target = '2.0'
   s.tvos.deployment_target = '9.0'
-  s.compiler_flags = '-fobjc-arc-exceptions'
 
   s.source_files = 'stream-j2objc/**/*.{h,m}'
-  s.dependency 'J2ObjC@mirego', '1.0.0.2'
+  
+  s.dependency 'J2ObjC@mirego', '>= ${project.j2objc.version}'
 end


### PR DESCRIPTION
The Java sources are converted to Objective-C when the pod is installed so that the project can control what version of J2ObjC to use.

Projects can continue to use version 1.0.0.2 or upgrade to 2.4 if they are ready to.

Will also now build in manual reference counting mode.
9fddbb0