### PR TITLE
Support J2objc 2.x by not flattening the folders

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -7,3 +7,9 @@ Add this to your project `header-mapping.j2objc`.
 ```
 com.annimon.stream.Stream=CASStream.h
 ```
+
+## V1.2.17
+### BREAKING CHANGE
+Header directory structure is now maintained, removing the need for `header-mapping.j2objc` entries
+
+Remove all entries starting by `com.animon.stream.*` from your project mapping file

--- a/J2OBJC-USAGE.md
+++ b/J2OBJC-USAGE.md
@@ -7,7 +7,7 @@
 ```
 dependencies {
 	...
-	compile 'com.mirego.annimon:stream:1.2.16'
+	compile 'com.mirego.annimon:stream:1.2.17'
 	...
 }
 ```
@@ -17,36 +17,5 @@ dependencies {
 - Ajouter la dépendance dans votre `*core.podspec.template`
 
 ```
-s.dependency 'lightweight-stream-api', '1.2.16'
-```
-
-## Header mapping pour iOS
-
-Certains fichiers `.h` générés pour `stream-api` entrent en conflit avec des header de `jre-emul`
-
-
-### Si votre projet n'a pas de header mapping:
-- Créer un fichier texte appelé `header-mapping.j2objc` à la racine du core avec les entrées suivantes:
-
-### Si le votre projet a déjà du header mapping: 
-
-- Ajouter les entrées suivantes au fichier de header mapping (normalement nommé `header-mapping.j2objc') dans le Core du project
-
-```
-com.annimon.stream.Optional=CASOptional.h
-com.annimon.stream.function.Function=CASFunction.h
-com.annimon.stream.Objects=CASObjects.h
-com.annimon.stream.function.Predicate=CASPredicate.h
-com.annimon.stream.function.Supplier=CASSupplier.h
-com.annimon.stream.Stream=CASStream.h
-```
-
-- Ajouter l'option `--header-mapping` au plugin j2objc 
-
-```
-j2objc {
-	...
-	options += ' --header-mapping header-mapping.j2objc'
-	...
-}
+s.dependency 'lightweight-stream-api', '1.2.17'
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 // Plugins
 plugins {
-    id "net.saliman.cobertura" version "2.2.6"
-    id "com.github.kt3k.coveralls" version "2.8.1"
-    id "me.champeau.gradle.jmh" version "0.4.4"
+    id "net.saliman.cobertura" version "3.0.0"
+    id "com.github.kt3k.coveralls" version "2.9.0"
+    id "me.champeau.gradle.jmh" version "0.5.0"
 }
 
 allprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://s3.amazonaws.com/shared.ws.mirego.com/gradle-dists/gradle-4.10-mirego-2-all.zip
+distributionUrl=https\://s3.amazonaws.com/shared.ws.mirego.com/gradle-dists/gradle-5.5.1-mirego-1-all.zip

--- a/lightweight-stream-api.podspec.template
+++ b/lightweight-stream-api.podspec.template
@@ -19,6 +19,7 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '9.0'
 
   s.source_files = 'stream-j2objc/**/*.{h,m}'
-  
+  s.header_mappings_dir = 'stream-j2objc'
+
   s.dependency 'J2ObjC@mirego', '>= ${project.j2objc.version}'
 end

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
+    testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
     testImplementation project(':streamTest')
 }
 
@@ -43,8 +44,8 @@ jmh {
 }
 
 task sourceJar(type: Jar) {
+    archiveClassifier.set('sources')
     from sourceSets.main.allJava
-    classifier = 'sources'
 }
 
 j2objc {
@@ -60,7 +61,7 @@ j2objc {
             'com.annimon.stream.*': 'CAS'
     ]
 
-	options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --nullability --swift-friendly'
+    options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --nullability --swift-friendly'
 }
 
 release {

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'me.champeau.gradle.jmh'
     id 'mirego.publish' version '1.0'
     id 'mirego.release' version '1.13'
-    id 'mirego.j2objc' version '1.59'
+    id 'mirego.j2objc' version '1.60'
 }
 
 archivesBaseName = 'stream'
@@ -60,27 +60,7 @@ j2objc {
             'com.annimon.stream.*': 'CAS'
     ]
 
-    options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --no-package-directories --nullability --swift-friendly --header-mapping header-mapping.j2objc'
-}
-
-tasks['j2objc'].doLast {
-    // Some hacking:
-    // The following files generate header file names that clash with jre-emul after transpilling
-    // Renaming header and source files to CAS*.h and CAS*.m and the --header-mapping replace the #include references
-    renameHeader('Optional', 'CAS') // Optional.java
-    renameHeader('Function', 'CAS') // Function.java
-    renameHeader('Objects', 'CAS') // Objects.java
-    renameHeader('Predicate', 'CAS') // Predicate.java
-    renameHeader('Supplier', 'CAS') // Supplier.java
-    renameHeader('Stream', 'CAS') // Stream.java
-}
-
-def renameHeader(fileName, prefix) {
-    def genDir = file(project.extensions['j2objc'].generatedDir)
-    new File(genDir, fileName +'.h').renameTo(new File(genDir, prefix + fileName + '.h'))
-    def mFile = new File(genDir, fileName + '.m')
-    mFile.text = mFile.text.replaceAll('#include "' + fileName + '.h"', '#include "' + prefix + fileName + '.h"')
-    mFile.renameTo(new File(genDir, prefix + fileName+ '.m'))
+	options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --nullability --swift-friendly'
 }
 
 release {

--- a/stream/header-mapping.j2objc
+++ b/stream/header-mapping.j2objc
@@ -1,6 +1,0 @@
-com.annimon.stream.Optional=CASOptional.h
-com.annimon.stream.function.Function=CASFunction.h
-com.annimon.stream.Objects=CASObjects.h
-com.annimon.stream.function.Predicate=CASPredicate.h
-com.annimon.stream.function.Supplier=CASSupplier.h
-com.annimon.stream.Stream=CASStream.h

--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -24,6 +24,7 @@ dependencies {
     api 'org.mockito:mockito-core:2.19.0'
     testImplementation 'org.hamcrest:hamcrest-library:1.3'
     testImplementation group: 'junit', name: 'junit', version: '4.12'
+    testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
 }
 
 cobertura {

--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -6,8 +6,8 @@ version = '1.2.1-SNAPSHOT'
 group = 'com.annimon'
 ext.isReleaseVersion = !version.contains("SNAPSHOT")
 
-sourceCompatibility = '1.6'
-targetCompatibility = '1.6'
+sourceCompatibility = '1.7'
+targetCompatibility = '1.7'
 [compileJava, compileTestJava]*.options*.encoding = 'UTF-8'
 
 if (!hasProperty('mainClass')) {


### PR DESCRIPTION
This PR updates dependencies and changes the j2objc transpilation to keep the folder structure so it does not clash with files from jre_emul (or other libraries)

This is basically all that is needed to support j2objc 2.x 

BREAKING change: header mapping for `com.animon.stream.*` must be removed from projects