### PR TITLE
Update j2objc plugin to support multiple version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 local.properties
 
 stream-j2objc
-lightweight-stream-api.podspec
+lightweight-stream-api*.podspec

--- a/lightweight-stream-api.podspec.template
+++ b/lightweight-stream-api.podspec.template
@@ -1,5 +1,5 @@
 Pod::Spec.new do |s|
-  s.name     = 'lightweight-stream-api'
+  s.name     = '${podName}'
   s.version  = '${project.version}'
   s.license  = { :type => 'PRIVATE', :text => 'PRIVATE' }
   s.summary  = 'Stream api port to Java 7.'
@@ -10,6 +10,7 @@ Pod::Spec.new do |s|
 
   s.prepare_command = <<-CMD
     export ANDROID_HOME="\${ANDROID_HOME:-\$HOME/Library/Android/sdk}"
+    export J2OBJC_VERSION="${j2objcVersion}"
     ./gradlew j2objc
   CMD
 
@@ -21,5 +22,5 @@ Pod::Spec.new do |s|
   s.source_files = 'stream-j2objc/**/*.{h,m}'
   s.header_mappings_dir = 'stream-j2objc'
 
-  s.dependency 'J2ObjC@mirego', '>= ${project.j2objc.version}'
+  s.dependency 'J2ObjC@mirego', '>= ${j2objcVersion}'
 end

--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -3,7 +3,7 @@ plugins {
     id 'me.champeau.gradle.jmh'
     id 'mirego.publish' version '1.0'
     id 'mirego.release' version '1.13'
-    id 'mirego.j2objc' version '1.60'
+    id 'mirego.j2objc' version '1.66'
 }
 
 archivesBaseName = 'stream'
@@ -50,6 +50,7 @@ task sourceJar(type: Jar) {
 
 j2objc {
     version = '2.4'
+    supportedVersions = ['1.0.0.2', '2.4', '2.5']
 
     podName = 'lightweight-stream-api'
     podspecFile = "../${j2objc.podName}.podspec"


### PR DESCRIPTION
- Update the plugin
- Add all supported versions
- Change the podspec.template to use `${podName}` to be properly templated for each version
- Set J2OBJC_VERSION envVar in prepare