### PR TITLE
Adding missing @Deprecated annotation to deprecated method

### DIFF
--- a/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
+++ b/stream/src/main/java/com/annimon/stream/ComparatorCompat.java
@@ -390,6 +390,7 @@ public final class ComparatorCompat<T> implements Comparator<T> {
      * @return a comparator
      */
     @SuppressWarnings("unchecked")
+    @Deprecated
     public Comparator<T> comparator() {
         return (Comparator<T>) comparator;
     }


### PR DESCRIPTION
This annotation is mandatory for compiling with java 11.