### PR TITLE
Replace jcenter with mavenCentral

### DIFF
--- a/stream/build.gradle
+++ b/stream/build.gradle
@@ -20,7 +20,7 @@ if (!hasProperty('mainClass')) {
 
 repositories {
     mavenLocal()
-    jcenter()
+    mavenCentral()
     delegate.miregoPublic()
 }
 
@@ -62,7 +62,7 @@ j2objc {
         'com.annimon.stream.*': 'CAS'
     ]
 
-    //Rewrite options to ommit --no-package-directories
+    //Rewrite options to omit --no-package-directories
     options = '-encoding UTF-8 -Werror --build-closure --doc-comments --generate-deprecated -J-Xmx2G --nullability --swift-friendly'
 }
 

--- a/streamTest/build.gradle
+++ b/streamTest/build.gradle
@@ -15,7 +15,7 @@ if (!hasProperty('mainClass')) {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## 📖 Description

We replace `jcenter` with `mavenCentral` in repositories.