### PR TITLE
Add Swift Package Manager distribution

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,11 @@ jobs:
           key: ${{ secrets.MIREGO_GITHUB_SSH_PRIVATE_KEY }}
           known_hosts: unnecessary
 
+      # Lets `swift package resolve` (in spmPublish's xcframework build) fetch the
+      # J2ObjC runtime SPM package over SSH during release.
+      - name: Use SSH for GitHub HTTPS URLs
+        run: git config --global url."git@github.com:".insteadOf "https://github.com/"
+
       - name: Release
         env:
           MAVEN_AWS_KEY: ${{ secrets.MIREGO_MAVEN_AWS_ACCESS_KEY_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,11 @@
 local.properties
 
 stream-j2objc
+
+# SwiftPM: generated manifest + local build artifacts. The xcframework is NOT kept
+# on the branch — spm-publish.sh attaches it only to the SemVer release tag.
+/Package.swift
+/Package.resolved
+/.build/
+/build-xcframework/
+/*.xcframework

--- a/Package.swift.template
+++ b/Package.swift.template
@@ -1,0 +1,37 @@
+// swift-tools-version:5.9
+//
+// GENERATED from Package.swift.template by the `spmPackage` Gradle task — do not
+// edit by hand. The dependency version comes from gradle.properties (single source).
+//
+import PackageDescription
+
+// Lightweight-Stream-API — J2ObjC library, distributed for Swift Package Manager.
+// Generated Obj-C (MRC) pre-compiled into LightweightStreamApi.xcframework. Unlike
+// the flat-header libs, this one keeps package directories (com/annimon/stream/...);
+// the headers ship structured and consumers include them by package path via
+// J2ObjC header-mapping. Depends only on the J2ObjC runtime (objects resolved once
+// at the consumer's final link).
+let package = Package(
+    name: "LightweightStreamApi",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(name: "LightweightStreamApi", targets: ["LightweightStreamApi"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/mirego/j2objc.git", from: "@J2OBJC_SPM_VERSION@")
+    ],
+    targets: [
+        // Committed at the release tag (private repo → consumed via authenticated git clone).
+        .binaryTarget(
+            name: "LightweightStreamApiObjC",
+            path: "LightweightStreamApi.xcframework"
+        ),
+        .target(
+            name: "LightweightStreamApi",
+            dependencies: [
+                "LightweightStreamApiObjC",
+                .product(name: "J2ObjCRuntime", package: "j2objc")
+            ]
+        )
+    ]
+)

--- a/Sources/LightweightStreamApi/Placeholder.swift
+++ b/Sources/LightweightStreamApi/Placeholder.swift
@@ -1,0 +1,4 @@
+// Intentionally empty. The `LightweightStreamApi` wrapper target bundles the
+// pre-compiled LightweightStreamApi.xcframework with the J2ObjC runtime SPM
+// dependency, which provides the symbols it links against at the consumer's
+// final link.

--- a/build.gradle
+++ b/build.gradle
@@ -11,20 +11,56 @@ release {
     ]
 
     preTagCommitTasks = [
-        'stream:j2objc_podspec'
+        'stream:j2objc_podspec',
+        'spmPackage'
     ]
 
     buildTasks = [
         'stream:publish',
-        'stream:j2objc_repo_push_quick'
+        'stream:j2objc_repo_push_quick',
+        'spmPublish'
     ]
 
     commitNewVersionTasks = [
-        'stream:j2objc_podspec'
+        'stream:j2objc_podspec',
+        'spmPackage'
     ]
 
     updateVersionPart = 2
     tagPrefix = 'lightweight-stream-'
+}
+
+// Generate Package.swift from Package.swift.template, single-sourcing the SPM
+// dependency version from gradle.properties (SemVer = "<x.y>" -> "<x.y>.0").
+// Mirrors j2objc_podspec; runs in the release commit hooks so the manifest stays
+// in sync with the runtime dependency version.
+task spmPackage {
+    group = 'Build'
+    description = 'Generate Package.swift from the template using gradle.properties versions.'
+    doLast {
+        def semver = { v -> def b = "${v}"; b.tokenize('.').size() >= 3 ? b : "${b}.0" }
+        file('Package.swift').text = file('Package.swift.template').text
+                .replace('@J2OBJC_SPM_VERSION@', semver(j2objc_version))
+    }
+}
+
+// Build the xcframework and publish its SPM SemVer tag (e.g. 1.2.30). Runs in
+// `release` (buildTasks) after the J2ObjC transpile. On CI it commits the
+// xcframework + manifest and pushes the tag; locally it is a build-only dry run.
+task spmPublish(type: Exec) {
+    group = 'Release'
+    description = 'Build the xcframework and publish its SPM SemVer tag.'
+    // Ensure the generated Obj-C exists in THIS gradle invocation (the release
+    // plugin runs build tasks in a separate invocation from the check phase).
+    dependsOn ':stream:j2objc'
+    workingDir = rootDir
+    commandLine 'bash', 'scripts/spm-publish.sh'
+    doFirst {
+        def base = project.version.toString().replaceAll(/-SNAPSHOT$/, '')
+        def semver = base.tokenize('.').size() >= 3 ? base : "${base}.0"
+        environment 'SPM_VERSION', semver
+        environment 'PUBLISH', (System.getenv('GITHUB_ACTIONS') ? '1' : '0')
+    }
 }
 
 allprojects {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,6 @@
 #Wed Mar 11 16:38:32 UTC 2026
 group=com.mirego.annimon
+j2objc_version=3.1
 mirego_j2objc_plugin_version=3.1
 mirego_publish_plugin_version=1.6
 mirego_release_plugin_version=2.10

--- a/scripts/build-xcframework.sh
+++ b/scripts/build-xcframework.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Build LightweightStreamApi.xcframework from the J2ObjC-generated Obj-C (MRC only
+# — no hand-written iOS layer). Depends only on the J2ObjC runtime headers at
+# COMPILE time (their objects are NOT embedded; symbols resolve at the consumer's
+# final link via the runtime's own SPM package).
+#
+# NOTE: unlike scratch/itch (which generate flat headers via
+# --no-package-directories), this lib KEEPS package directories
+# (com/annimon/stream/...) and its sources #include via those package paths
+# (e.g. #include "com/annimon/stream/Optional.h"). So we stage headers preserving
+# the tree and put the tree root on the include path. Consumers (e.g. canadiens
+# core) reference the same package paths via J2ObjC header-mapping, so the
+# xcframework must ship the structured headers. NO module map (textual includes;
+# an umbrella map would break the J2ObjC INCLUDE_ALL/RESTRICT guards — see
+# spm-no-module-maps).
+#
+# Slices: ios-arm64_arm64e (device) + ios-arm64 (simulator, Apple Silicon).
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+ROOT="$(pwd)"
+
+NAME="LightweightStreamApi"
+MIN_IOS="12.0"
+BUILD="${ROOT}/build-xcframework"
+OUT="${ROOT}/${NAME}.xcframework"
+
+GENERATED_DIRS=("${ROOT}/stream-j2objc")     # MRC, package-structured
+ARC_DIRS=()                                   # none
+
+# Upstream headers needed to COMPILE (not embed): the J2ObjC runtime only.
+RUNTIME_INC="${RUNTIME_INC:-$HOME/.j2objc/j2objc-3.1-mirego/include}"
+JSR305_INC="${JSR305_INC:-$HOME/.j2objc/j2objc-3.1-mirego/frameworks/JSR305.xcframework/ios-arm64_arm64e/Headers}"
+UPSTREAM_INCS=("${RUNTIME_INC}" "${JSR305_INC}")
+
+MRC_FLAGS=(-fno-objc-arc -fobjc-weak
+    -Wno-nullability-completeness -Wno-deprecated-declarations
+    -Wno-strict-prototypes -Wno-documentation -Wno-unused-variable
+    -Wno-unused-but-set-variable -Wno-unused-label -Wno-dangling-else
+    -Wno-conditional-uninitialized)
+ARC_FLAGS=(-fobjc-arc -fobjc-arc-exceptions -fobjc-weak
+    -Wno-nullability-completeness -Wno-deprecated-declarations)
+
+INC_FLAGS=(-I"${BUILD}/Headers")
+for d in "${UPSTREAM_INCS[@]}"; do INC_FLAGS+=(-I"${d}"); done
+
+rm -rf "${BUILD}" "${OUT}"
+mkdir -p "${BUILD}/Headers"
+
+echo "Staging headers (preserving package dirs)..."
+for d in ${GENERATED_DIRS[@]+"${GENERATED_DIRS[@]}"}; do cp -R "${d}/." "${BUILD}/Headers/"; done
+find "${BUILD}/Headers" -name '*.m' -delete
+echo "  $(find "${BUILD}/Headers" -name '*.h' | wc -l | tr -d ' ') headers"
+
+GEN_SRCS=(); for d in ${GENERATED_DIRS[@]+"${GENERATED_DIRS[@]}"}; do while IFS= read -r f; do GEN_SRCS+=("$f"); done < <(find "${d}" -name '*.m'); done
+ARC_SRCS=(); for d in ${ARC_DIRS[@]+"${ARC_DIRS[@]}"}; do while IFS= read -r f; do ARC_SRCS+=("$f"); done < <(find "${d}" -name '*.m'); done
+
+compile_group () {
+    local objdir="$1" sdkpath="$2" mintarget="$3"; shift 3
+    mkdir -p "${objdir}"
+    ( cd "${objdir}" && xcrun --sdk "${SDK}" clang -c "$@" -isysroot "${sdkpath}" "${mintarget}" "${INC_FLAGS[@]}" )
+}
+
+build_slice () {
+    local slice="$1"; SDK="$2"; shift 2
+    local archs=("$@")
+    local sdkpath; sdkpath="$(xcrun --sdk "${SDK}" --show-sdk-path)"
+    local objdir="${BUILD}/${slice}"
+    local archflags=(); for a in "${archs[@]}"; do archflags+=(-arch "${a}"); done
+    local mintarget
+    if [ "${SDK}" = "iphonesimulator" ]; then mintarget="-mios-simulator-version-min=${MIN_IOS}"; else mintarget="-miphoneos-version-min=${MIN_IOS}"; fi
+
+    local libs=()
+    if [ "${#GEN_SRCS[@]}" -gt 0 ]; then
+        echo "  compiling generated (MRC)..."
+        compile_group "${objdir}/gen" "${sdkpath}" "${mintarget}" "${archflags[@]}" "${MRC_FLAGS[@]}" "${GEN_SRCS[@]}"
+        libs+=("${objdir}"/gen/*.o)
+    fi
+    if [ "${#ARC_SRCS[@]}" -gt 0 ]; then
+        echo "  compiling iOS layer (ARC)..."
+        compile_group "${objdir}/arc" "${sdkpath}" "${mintarget}" "${archflags[@]}" "${ARC_FLAGS[@]}" "${ARC_SRCS[@]}"
+        libs+=("${objdir}"/arc/*.o)
+    fi
+    xcrun libtool -static -o "${BUILD}/lib${NAME}-${slice}.a" "${libs[@]}"
+    echo "  ${slice}: $(lipo -archs "${BUILD}/lib${NAME}-${slice}.a")"
+}
+
+echo "Building device slice..."
+build_slice "device" "iphoneos" arm64 arm64e
+echo "Building simulator slice..."
+build_slice "sim" "iphonesimulator" arm64
+
+echo "Creating xcframework..."
+xcodebuild -create-xcframework \
+    -library "${BUILD}/lib${NAME}-device.a" -headers "${BUILD}/Headers" \
+    -library "${BUILD}/lib${NAME}-sim.a" -headers "${BUILD}/Headers" \
+    -output "${OUT}"
+
+echo "Done: ${OUT}"
+plutil -p "${OUT}/Info.plist" | grep -E "LibraryIdentifier|SupportedPlatformVariant" || true

--- a/scripts/spm-publish.sh
+++ b/scripts/spm-publish.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Build this library's xcframework and publish its SPM SemVer tag. Invoked by the
+# `spmPublish` Gradle task during `release` (after the J2ObjC transpile in the
+# release check tasks). Generic across the J2ObjC libs (private repos → the
+# xcframework is committed at the tag and consumed via .binaryTarget(path:)).
+#
+# The xcframework is large and is NOT kept on the branch: we attach it to a commit
+# made with `git commit-tree` (which does NOT move HEAD/the branch) and push only
+# the SemVer TAG. So `master` stays clean while the tag carries the binary — even
+# though the surrounding `release` flow pushes the branch afterwards.
+#
+# Env:
+#   SPM_VERSION  SemVer tag to publish (e.g. 1.521.0)  (required)
+#   PUBLISH      1 = build + tag + push; 0 = build-only dry run (default: 0)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+SPM_VERSION="${SPM_VERSION:?set SPM_VERSION}"
+PUBLISH="${PUBLISH:-0}"
+
+echo "==> Building xcframework"
+./scripts/build-xcframework.sh
+
+if [ "${PUBLISH}" != "1" ]; then
+  echo "==> PUBLISH=0 (dry run): built only, not tagging."
+  exit 0
+fi
+
+echo "==> Tagging ${SPM_VERSION} with the xcframework (without moving the branch)"
+git add -f ./*.xcframework
+tree="$(git write-tree)"
+commit="$(git -c user.name="GitHub Actions" -c user.email="actions@github.com" \
+            commit-tree "${tree}" -p HEAD -m "Swift Package Manager xcframework ${SPM_VERSION}")"
+git read-tree HEAD            # restore the index; HEAD/branch are untouched
+git tag -f "${SPM_VERSION}" "${commit}"
+git push -f origin "${SPM_VERSION}"   # tag-only push; the binary rides along with the tag
+echo "==> Published ${SPM_VERSION} (master left clean)"


### PR DESCRIPTION
## What
Distributes the J2ObjC-generated Obj-C as `LightweightStreamApi.xcframework` via Swift Package Manager, mirroring the scratch/itch pattern, alongside the existing CocoaPods/Maven artifacts.

- `scripts/build-xcframework.sh` builds the MRC xcframework. Unlike the flat-header libs, this one **keeps package directories** (`com/annimon/stream/...`) and its sources `#include` by package path, so headers ship structured and consumers resolve them by package path via J2ObjC header-mapping.
- `scripts/spm-publish.sh` attaches the xcframework to the SemVer tag via `git commit-tree` (master stays clean; the binary rides the tag).
- `Package.swift` is generated from `Package.swift.template` by the `spmPackage` Gradle task (single-sources the runtime version from `gradle.properties`); depends only on the public J2ObjC runtime SPM package.
- Wired into `release`: `spmPackage` (preTagCommit/commitNewVersion) + `spmPublish` (buildTasks), so `./gradlew release` cuts the SPM SemVer tag (`1.2.30`) too. `release.yml` gains the SSH `insteadOf` step.

## Validation
Local: xcframework builds (both slices, MRC clean, 204 headers); generated `Package.swift` resolves the runtime from the public `mirego/j2objc` package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)