### PR TITLE
Track Package.swift so it rides the release tag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,9 +17,9 @@ local.properties
 
 stream-j2objc
 
-# SwiftPM: generated manifest + local build artifacts. The xcframework is NOT kept
-# on the branch — spm-publish.sh attaches it only to the SemVer release tag.
-/Package.swift
+# SwiftPM local build artifacts. Package.swift IS tracked (generated from the
+# template but committed so it rides the release tag, like the other libs). The
+# xcframework is NOT kept on the branch — spm-publish.sh attaches it only to the tag.
 /Package.resolved
 /.build/
 /build-xcframework/

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,37 @@
+// swift-tools-version:5.9
+//
+// GENERATED from Package.swift.template by the `spmPackage` Gradle task — do not
+// edit by hand. The dependency version comes from gradle.properties (single source).
+//
+import PackageDescription
+
+// Lightweight-Stream-API — J2ObjC library, distributed for Swift Package Manager.
+// Generated Obj-C (MRC) pre-compiled into LightweightStreamApi.xcframework. Unlike
+// the flat-header libs, this one keeps package directories (com/annimon/stream/...);
+// the headers ship structured and consumers include them by package path via
+// J2ObjC header-mapping. Depends only on the J2ObjC runtime (objects resolved once
+// at the consumer's final link).
+let package = Package(
+    name: "LightweightStreamApi",
+    platforms: [.iOS(.v12)],
+    products: [
+        .library(name: "LightweightStreamApi", targets: ["LightweightStreamApi"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/mirego/j2objc.git", from: "3.1.0")
+    ],
+    targets: [
+        // Committed at the release tag (private repo → consumed via authenticated git clone).
+        .binaryTarget(
+            name: "LightweightStreamApiObjC",
+            path: "LightweightStreamApi.xcframework"
+        ),
+        .target(
+            name: "LightweightStreamApi",
+            dependencies: [
+                "LightweightStreamApiObjC",
+                .product(name: "J2ObjCRuntime", package: "j2objc")
+            ]
+        )
+    ]
+)


### PR DESCRIPTION
## Bug
The `1.2.30` release tag carries `Package.swift.template` + `LightweightStreamApi.xcframework` but **no `Package.swift`**, so SPM can't resolve the package (`Package.swift doesn't exist`). Root cause: `Package.swift` was git-ignored, so the release commit / `spmPublish` only put the (force-added) xcframework on the tag — the generated manifest was never committed.

## Fix
Track `Package.swift` (remove it from `.gitignore` + commit the rendered manifest), matching scratch/itch/scratch-model/circumflex, whose tags carry `Package.swift` and resolve fine. `spmPackage` still regenerates it at release (preTagCommit), so the tag always gets the up-to-date manifest.

After merge, **re-run the Release workflow** to cut a new tag (≈ `1.2.31`) that includes `Package.swift`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)